### PR TITLE
Use positional arguments for navarchiver scheduled mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,35 @@ Navarchiver archives your [Navidrome](https://www.navidrome.org/) audio library 
 
 It runs in 3 modes:
 
-* [Scheduled](#scheduled)
-* [Ledger](#ledger)
-* [Batch](#batch)
+- [Scheduled](#scheduled)
+- [Ledger](#ledger)
+- [Batch](#batch)
 
 Tested on versions:
 
-* [v0.54.5](https://github.com/navidrome/navidrome/releases/tag/v0.54.5)
-* [v0.58.0](https://github.com/navidrome/navidrome/releases/tag/v0.58.0)
+- [v0.54.5](https://github.com/navidrome/navidrome/releases/tag/v0.54.5)
+- [v0.58.0](https://github.com/navidrome/navidrome/releases/tag/v0.58.0)
 
 ## Scheduled
+
 Scheduled mode is designed to be used for archiving the library "moving forward" on a nightly basis. For backfilling, use [batch mode](#batch).
 
-Scheduled mode should run in same directory as where you keep your navidrome DB.
+Scheduled mode takes 2 positional arguments for:
+
+- Location of the Navidrome SQLite DB file
+- Location for the Navarchiver SQLite DB file
 
 ### Environment variables
 
-* GCS_PROJECT_ID - Project ID for GCS uploading
-* GCS_BUCKET_NAME - Bucket name for GCS uploading
-* GCS_TIMEOUT_SECONDS - maximum time to allow for a GCS upload before timing out
-* GCS_CREDS_FILE - path to GCS JSON credentials file
+- GCS_PROJECT_ID - Project ID for GCS uploading
+- GCS_BUCKET_NAME - Bucket name for GCS uploading
+- GCS_TIMEOUT_SECONDS - maximum time to allow for a GCS upload before timing out
+- GCS_CREDS_FILE - path to GCS JSON credentials file
 
 For alerting, [discord-alert](https://github.com/apkatsikas/discord-alert) is used. Please see the documentation for this tool and for more info on [creating a bot](https://github.com/apkatsikas/discord-alert?tab=readme-ov-file#creating-a-bot).
 
-* BOT_TOKEN - Discord bot token for alerting on failure of the nightly backup
-* CHANNEL_ID - Discord channel ID for alerting
+- BOT_TOKEN - Discord bot token for alerting on failure of the nightly backup
+- CHANNEL_ID - Discord channel ID for alerting
 
 ### Running scheduled mode
 
@@ -42,10 +46,10 @@ Batch mode takes a JSON file produced by the [ledger mode](#ledger). You might c
 
 You will need to set:
 
-* GCS_PROJECT_ID
-* GCS_BUCKET_NAME
-* GCS_TIMEOUT_SECONDS
-* GCS_CREDS_FILE
+- GCS_PROJECT_ID
+- GCS_BUCKET_NAME
+- GCS_TIMEOUT_SECONDS
+- GCS_CREDS_FILE
 
 from the [environment variables](#environment-variables) section.
 
@@ -57,5 +61,5 @@ The ledger mode produces a JSON file suitable for backfilling a batch in [batch 
 
 This mode is invoked using the `-runMode=ledger` flag, and takes 2 positional arguments for:
 
-* Location of the Navidrome SQLite DB file
-* Destination for the ledger JSON file
+- Location of the Navidrome SQLite DB file
+- Destination for the ledger JSON file

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ One nice way to run scheduled mode is a Linux cron job.
 
 An example cron command might look like:
 
-`cd /var/lib/navidrome && /opt/navarchiver/navarchiver >> /var/lib/navidrome/archiver.log 2>&1`
+`cd /var/lib/navidrome && /opt/navarchiver/navarchiver navidrome.db archive_run.db >> /var/lib/navidrome/archiver.log 2>&1`
 
 ## Batch
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -93,17 +93,26 @@ func runBatch() error {
 }
 
 func performScheduledArchive() error {
-	fso := &fileutil.FileSystemOperator{}
+	arguments := flag.Args()
+
+	if len(arguments) < 2 {
+		return fmt.Errorf("scheduled mode requires arguments for navidrome DB path and archive DB path")
+	}
+
+	navidromeDbPath := arguments[0]
+	archiveDbPath := arguments[1]
 
 	sqliteHandlerArchiveRun := &db.SQLiteHandler{}
-	if err := sqliteHandlerArchiveRun.ConnectSQLite("archive_run.db"); err != nil {
+	if err := sqliteHandlerArchiveRun.ConnectSQLite(archiveDbPath); err != nil {
 		return err
 	}
 
 	sqliteNavidrome := &db.SQLiteHandler{}
-	if err := sqliteNavidrome.ConnectSQLite("navidrome.db"); err != nil {
+	if err := sqliteNavidrome.ConnectSQLite(navidromeDbPath); err != nil {
 		return err
 	}
+
+	fso := &fileutil.FileSystemOperator{}
 
 	runn := &runner.Runner{
 		FilterService:          &filter.FilterService{},


### PR DESCRIPTION
Instead of hardcoding the paths for the navidrome DB and the navarchiver SQLite DB files, this PR updates navarchiver to use positional arguments in scheduled mode.